### PR TITLE
Refactors code for readability

### DIFF
--- a/lib/hubotex/matcher.ex
+++ b/lib/hubotex/matcher.ex
@@ -26,8 +26,8 @@ defmodule Hubotex.Matcher do
   
   defp acc_results({message, []}), do: {:nomatch, message}
   defp acc_results({_message, results}) do
-    Enum.reduce(results, fn {:ok, result}, {:ok, response} ->
-      {:ok, "#{response}\n#{result}"}
+    Enum.reduce(results, fn {:ok, result}, {:ok, acc_response} ->
+      {:ok, "#{acc_response}\n#{result}"}
     end)
   end
   

--- a/lib/hubotex/matcher.ex
+++ b/lib/hubotex/matcher.ex
@@ -1,4 +1,5 @@
 defmodule Hubotex.Matcher do
+
   def match(message, rules) do
     {message, rules}
     |> map_rules
@@ -9,7 +10,11 @@ defmodule Hubotex.Matcher do
   defp map_rules({message, rules}) do
     results = Enum.map(rules, fn rule ->
       {regex, consequence} = rule
-      if rule_match?(regex, message), do: {:ok, consequence.(message)}, else: {:nomatch}
+      if rule_match?(regex, message) do
+        {:ok, consequence.(message)}
+      else
+        {:nomatch}
+      end
     end)
     {message, results}
   end
@@ -20,7 +25,11 @@ defmodule Hubotex.Matcher do
   end
   
   defp acc_results({message, []}), do: {:nomatch, message}
-  defp acc_results({_message, results}), do: Enum.reduce(results, fn {:ok, result}, {:ok, response} -> {:ok, "#{response}\n#{result}"} end)
+  defp acc_results({_message, results}) do
+    Enum.reduce(results, fn {:ok, result}, {:ok, response} ->
+      {:ok, "#{response}\n#{result}"}
+    end)
+  end
   
   defp rule_match?(regex, message) do
     Regex.match?(regex, message)

--- a/lib/hubotex/robot.ex
+++ b/lib/hubotex/robot.ex
@@ -15,6 +15,8 @@ defmodule Hubotex.Robot do
     {:reply, do_accept(message, state), state}
   end
 
+  ### end CallBacks ###
+
   defp do_accept(message, state) do
     {message, state}
     |> do_match


### PR DESCRIPTION
- Long if statements on the same line were too hard to read and grasp
- The `acc_results/1` function had too much on it to be a one line
  function. Makes more sense for it to be multiple lines
- Also, 80 columns :raised_hands: (I work on a 11" netbook :sweat_smile:)
