### PR TITLE
Adds an initial version of parallel matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Make use of the supervision trees.
 
 ##### Matcher
 - [x] Currently the matcher responds with the consequence of the first matcher. Ideally, consequences of all matchs should run and their results should be collated and responsed. But a match can specify to stop the matching process and respond with the results collated until now.
-- [ ] Matching must be parallelized (#3)
+- [ ] Matching must be parallelized ([#3](https://github.com/avinasha/hubotex/pull/3))
 
 ##### Adapter
 - [ ] Write a basic adapter (shell?)

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Make use of the supervision trees.
 
 ##### Matcher
 - [x] Currently the matcher responds with the consequence of the first matcher. Ideally, consequences of all matchs should run and their results should be collated and responsed. But a match can specify to stop the matching process and respond with the results collated until now.
-- [ ] Matching must be parallelized
+- [ ] Matching must be parallelized (#3)
 
 ##### Adapter
 - [ ] Write a basic adapter (shell?)

--- a/lib/hubotex/matcher.ex
+++ b/lib/hubotex/matcher.ex
@@ -7,7 +7,7 @@ defmodule Hubotex.Matcher do
   end
 
   defp map_rules({message, rules}) do
-    results = Enum.map(rules, fn rule ->
+    results = Parallel.pmap(rules, fn rule ->
       {regex, consequence} = rule
       if rule_match?(regex, message), do: {:ok, consequence.(message)}, else: {:nomatch}
     end)

--- a/lib/parallel.ex
+++ b/lib/parallel.ex
@@ -1,0 +1,12 @@
+defmodule Parallel do
+  def pmap(collection, fun) do
+    me = self
+    collection |> 
+    Enum.map(fn (elem) ->
+      spawn_link fn -> ( send me, { self, fun.(elem) } ) end
+    end) |>
+    Enum.map(fn (pid) ->
+      receive do { ^pid, result } -> result end
+    end)
+  end
+end


### PR DESCRIPTION
The easiest way to match in parallel would be to change the `Enum.map` function to be parallel. This follows the approach detailed out in [here](http://www.selectedintelligence.com/post/116327140769/parallel-map-in-elixir) and creates a new module - `parallel` which has a `pmap` function that is an implementation of `Enum.map` but in parallel. The gist of the approach being:
- Spawn a process for every rule that needs to be matched on and gather the pids
- Receive on the pids (sequentually, but we could skip this since sequence doesn't matter to us) and collate results
